### PR TITLE
Allow forcing SHA in options

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,9 @@ module.exports = function(owner, repo, options) {
 
   return commits(opts)
     .then(function(commits) {
-      opts.sha = commits[0].sha;
+      if (!opts.sha) {
+        opts.sha = commits[0].sha;
+      }
 
       return new Promise(function(resolve, reject) {
         github.get(url, opts, function(err, files) {


### PR DESCRIPTION
Since I'm using this as part of `github-download-directory` which will be used to pull down gulp docs, I'll need to be able to pull a branch while we work on updates.  This small change allows me to accept a branch name and pull that.